### PR TITLE
Mobile fix logo

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -2354,3 +2354,9 @@ video {
     text-align: left;
   }
 }
+
+@media (orientation: portrait) {
+  #logo {
+    height: 100px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
                         <div class="flex items-center justify-between w-full md:w-auto">
                             <a href="#">
                                 <span class="sr-only">Workflow</span>
-                                <img class="h-8 w-auto sm:h-10"
+                                <img id="logo" class="h-8 w-auto sm:h-10"
                                      src="images/csirt_global_logo.png"
                                      alt="">
                             </a>


### PR DESCRIPTION
This fixes issue #4  with the logo as the view width decreases, eventually, the logo gets stretched as the width is reduced beyond a minimal height, and the image is displayed with incorrect proportions (in a mobile view).

